### PR TITLE
Adding functionality for the SMS authenticator to be hit only on clicking the link

### DIFF
--- a/components/auth-proxy-service/src/main/java/com/wso2telco/proxy/util/DBUtils.java
+++ b/components/auth-proxy-service/src/main/java/com/wso2telco/proxy/util/DBUtils.java
@@ -17,6 +17,7 @@ package com.wso2telco.proxy.util;
 
 
 import com.wso2telco.core.config.model.LoginHintFormatDetails;
+import com.wso2telco.core.config.model.MobileConnectConfig;
 import com.wso2telco.core.config.model.ScopeParam;
 import com.wso2telco.core.config.service.ConfigurationService;
 import com.wso2telco.core.config.service.ConfigurationServiceImpl;

--- a/components/authentication-endpoint/src/main/webapp/mcx-user-registration/js/waiting/existing-user/waiting.js
+++ b/components/authentication-endpoint/src/main/webapp/mcx-user-registration/js/waiting/existing-user/waiting.js
@@ -140,18 +140,8 @@ function getCookieAndResend() {
 	});
 }
 
-function sendSMS(prefix){
-
-	var operator = getUrlVars()["operator"];
-	var client_id = getUrlVars()["relyingParty"];
-	var redirect_uri = getUrlVars()["redirect_uri"];
-	var acr_values = getUrlVars()["acr_values"];
-	var state = getUrlVars()["state"];
-	var scope = getUrlVars()["scope"];
-	var msisdn = document.getElementById('msisdn').value;
-	var nonce = getUrlVars()["nonce"];
-	var smsFallbackURL = prefix + "oauth2/authorize?scope=" + scope +"&response_type=code&redirect_uri=" + redirect_uri +"&client_id="+ client_id +"&msisdn="+msisdn +"&acr_values="+ "5" + "&state=" + state+ "&nonce=" + nonce;;
-
+function sendSMS(key,host,port){
+	var smsFallbackURL = "https://"+host+":"+port+"/commonauth?sessionDataKey="+key+"&smsrequested=true";
 	window.location = smsFallbackURL;
 }
 

--- a/components/authentication-endpoint/src/main/webapp/mcx-user-registration/waiting/existing-user/waiting-existing.jsp
+++ b/components/authentication-endpoint/src/main/webapp/mcx-user-registration/waiting/existing-user/waiting-existing.jsp
@@ -59,7 +59,7 @@
 		%>
 		<p class="page__copy flush">{{ussd-sent-resend-sms-prompt}}
 			<br>
-			<a onclick="sendSMS('<%=fallbackPrefix%>');" style="cursor:pointer"><u>
+			<a onclick="sendSMS('<%=request.getParameter("sessionDataKey")%>','<%=request.getRemoteHost()%>','<%=request.getLocalPort()%>');" style="cursor:pointer"><u>
 				{{ussd-sent-resend-sms-button}}
 			</u></a>
 		</p>

--- a/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/authenticators/ussd/USSDAuthenticator.java
+++ b/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/authenticators/ussd/USSDAuthenticator.java
@@ -31,7 +31,6 @@ import org.wso2.carbon.identity.application.authentication.framework.AbstractApp
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorFlowStatus;
 import org.wso2.carbon.identity.application.authentication.framework.LocalApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
-import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.LogoutFailedException;
@@ -198,6 +197,19 @@ public class USSDAuthenticator extends AbstractApplicationAuthenticator
     protected void processAuthenticationResponse(HttpServletRequest request,
                                                  HttpServletResponse response, AuthenticationContext context)
             throws AuthenticationFailedException {
+
+        if ("true".equals(request.getParameter("smsrequested"))) {
+            //This logic would get hit if the user hits the link to get an SMS so in that case
+            //We need to fallback. Therefore we through AuthenticationFailedException
+            throw new AuthenticationFailedException("USSD Authentication is skipped and moving forward to SMSAuthenticator");
+        } else {
+            //This logic would get hit whenever normal USSD Authentication flow is happening and in that case
+            //we don't need the SMSAuthenticator to be hit. Therefore, we set this property so that in the
+            //MIFEAuthenticationStepHandler, the steps following USSDAuthenticator will be removed.
+            //But please note that, this cause ANY step following USSDAuthenticator to be removed.
+            //Therefore, when redesigning, need to take this into consideration!
+            context.setProperty("removeFollowingSteps","true");
+        }
 
         String sessionDataKey = request.getParameter("sessionDataKey");
         boolean isRegistering = (boolean) context.getProperty(Constants.IS_REGISTERING);

--- a/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/handlers/authenticationstephandler/MIFEAuthenticationStepHandler.java
+++ b/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/handlers/authenticationstephandler/MIFEAuthenticationStepHandler.java
@@ -281,6 +281,14 @@ public class MIFEAuthenticationStepHandler extends DefaultStepHandler {
 			context.setAuthenticatorProperties(FrameworkUtils.getAuthenticatorPropertyMapFromIdP(
 					context.getExternalIdP(), authenticator.getName()));
 			AuthenticatorFlowStatus status = authenticator.process(request, response, context);
+
+			//The following if block is a part of implementing the functionality of SMSAuthenticator
+			//getting hit ONLY when the link to get a text message is clicked in the USSD waiting page.
+			//This ensures that after USSDAuthenticator is executed, SMS authenticator doesn't get hit.
+			if ("true".equals(context.getProperty("removeFollowingSteps"))) {
+				removeAllFollowingSteps(context,currentStep);
+				context.setProperty("removeFollowingSteps", null);
+			}
 			request.setAttribute(FrameworkConstants.RequestParams.FLOW_STATUS, status);
 			
 			//state validation
@@ -356,7 +364,13 @@ public class MIFEAuthenticationStepHandler extends DefaultStepHandler {
 			}
 
 		} catch (AuthenticationFailedException e) {
-
+			//The following if block is a part of implementing the functionality of SMSAuthenticator
+			//getting hit ONLY when the link to get a text message is clicked in the USSD waiting page.
+			//This ensures when USSDAuthenticator is failed, SMS authenticator doesn't get hit.
+			if ("true".equals(context.getProperty("removeFollowingSteps"))) {
+				removeAllFollowingSteps(context,currentStep);
+				context.setProperty("removeFollowingSteps", null);
+			}
 			if (e instanceof InvalidCredentialsException) {
 				log.warn("A login attempt was failed due to invalid credentials");
 			} else {


### PR DESCRIPTION
We need the SMSAuthenticator to be hit only if the link in the waiting page is clicked by the user. So, this PR has done a change in sendSMS function in waiting.js so that the commonauth servlet is being hit with the session data key and the newly introduced flag "smsrequested", when the link is clicked. At this moment, we are still inside the USSD authenticator and once the link is clicked processAuthenticationResponse method of the USSD authenticator will get hit. There, we throw an AuthenticationFailedException if the above mentioned flag is set. Then, the authentication will fallback to the SMSAuthenticator. (Note that we need to have the fallback level set properly in LOA.xml) 
Also, here, as we have set a fallback level BUT we need to fallback only when a link is clicked, we need to remove the following SMS authenticator step in any other case of failure. So, a property is set to identify whether the following steps should be removed. 