### PR TITLE
Adding SMSApprovalRequestForwardingFilter and refactoring SMSAuthenticator code

### DIFF
--- a/components/authentication-endpoint/src/main/webapp/login.jsp
+++ b/components/authentication-endpoint/src/main/webapp/login.jsp
@@ -460,7 +460,6 @@
 				} else if (localAuthenticatorNames.size() > 0 && localAuthenticatorNames.contains("SMSAuthenticator")) {
 					hasLocalLoginOptions = true;
 				%>
-				<input type="hidden" name="canHandleSMS" id="canHandleSMS" value='true'/>
 				<div class="row">
 					<div class="span12">
 

--- a/components/authentication-endpoint/src/main/webapp/mcx-user-registration/js/waiting/existing-user/waiting.js
+++ b/components/authentication-endpoint/src/main/webapp/mcx-user-registration/js/waiting/existing-user/waiting.js
@@ -74,11 +74,11 @@ function handleTermination() {
 	if(hasResponse){
 		commonAuthURL = "/commonauth/?sessionDataKey=" + sessionDataKey
 			+ "&msisdn=" + msisdn
-			+ "&isTerminated=false";
+			+ "&isTerminated=false&canHandle=true";
 	}else {
 		commonAuthURL = "/commonauth/?sessionDataKey=" + sessionDataKey
 			+ "&msisdn=" + msisdn
-			+ "&isTerminated=true";
+			+ "&isTerminated=true&canHandle=true";
 	}
 	window.location = commonAuthURL;
 	//}, 5000);

--- a/components/gsma-authenticators/pom.xml
+++ b/components/gsma-authenticators/pom.xml
@@ -124,6 +124,10 @@
             <version>2.0.13</version>
 			<scope>provided</scope>
         </dependency>
+		<dependency>
+			<groupId>org.hashids</groupId>
+			<artifactId>hashids</artifactId>
+		</dependency>
     </dependencies>
 	<build>
 		<plugins>

--- a/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/authenticators/Constants.java
+++ b/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/authenticators/Constants.java
@@ -343,4 +343,5 @@ public final class Constants {
 
     public static final String IP_ADDRESS = "ipAddress";
 
+    public static final String SESSION_UPDATER_SMS_RESPONSE_CONTEXT = "/sessionupdater/wt?id=";
 }

--- a/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/authenticators/DBUtils.java
+++ b/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/authenticators/DBUtils.java
@@ -108,9 +108,9 @@ public class DBUtils {
         //String sql = "SELECT SessionID, Status FROM clientstatus WHERE SessionID=?";
         StringBuilder sql = new StringBuilder();
 
-        sql.append("SELECT SessionID, Status FROM ");
-        sql.append(TableName.CLIENT_STATUS);
-        sql.append(" WHERE SessionID=?");
+        sql.append("SELECT status FROM ");
+        sql.append(TableName.REG_STATUS);
+        sql.append(" WHERE uuid=?");
 
         String userResponse = null;
         try {
@@ -119,10 +119,11 @@ public class DBUtils {
             ps.setString(1, sessionDataKey);
             results = ps.executeQuery();
             while (results.next()) {
-                userResponse = results.getString("Status");
+                userResponse = results.getString("status");
             }
         } catch (SQLException e) {
-            handleException("Error occured while getting User Response for SessionDataKey: " + sessionDataKey + " from the database", e);
+            handleException("Error occured while getting User Response for SessionDataKey: " + sessionDataKey
+                    + " from the database", e);
         } finally {
             IdentityDatabaseUtil.closeAllConnections(conn, results, ps);
         }
@@ -763,5 +764,24 @@ public class DBUtils {
             IdentityDatabaseUtil.closeAllConnections(conn, null, ps);
         }
         return -1;
+    }
+
+    public static void insertHashKeyContextIdentifierMapping(String hashKey, String contextIdentifier)
+            throws AuthenticatorException {
+        String sql = "insert into sms_hashkey_contextid_mapping(hashkey, contextid) values  (?,?);";
+
+        if (log.isDebugEnabled()) {
+            log.debug("Executing the query " + sql + " for hash key " + hashKey + " and context identifier "
+                    + contextIdentifier);
+        }
+
+        try (Connection connection = getConnectDBConnection()) {
+            PreparedStatement ps = connection.prepareStatement(sql.toString());
+            ps.setString(1, hashKey);
+            ps.setString(2, contextIdentifier);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            handleException(e.getMessage(), e);
+        }
     }
 }

--- a/components/session-updater/src/main/java/com/wso2telco/filters/SMSApprovalRequestForwardingFilter.java
+++ b/components/session-updater/src/main/java/com/wso2telco/filters/SMSApprovalRequestForwardingFilter.java
@@ -1,0 +1,34 @@
+package com.wso2telco.filters;
+
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * This filter forwards the requests coming for /wt request path to
+ * /tnspoints/endpoint/sms/response. The purpose of this is, to make the link
+ * sent to a user in SMS authenticator needs to be short as possible
+ */
+public class SMSApprovalRequestForwardingFilter implements Filter {
+
+    public void init(FilterConfig filterConfig) throws ServletException {
+       // Doesn't need implementation
+    }
+
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+            throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        RequestDispatcher requestDispatcher = request.getRequestDispatcher("/tnspoints/endpoint/sms/response");
+        requestDispatcher.forward(servletRequest, servletResponse);
+    }
+
+    public void destroy() {
+        // Doesn't need implementation
+    }
+}

--- a/components/session-updater/src/main/java/com/wso2telco/util/DbUtil.java
+++ b/components/session-updater/src/main/java/com/wso2telco/util/DbUtil.java
@@ -188,6 +188,22 @@ public class DbUtil {
         }
     }
 
+    public static String getContextIDForHashKey(String hashKey) throws AuthenticatorException, SQLException {
+        String sessionDataKey = null;
+
+        String sql = "select contextid from sms_hashkey_contextid_mapping where hashkey=?";
+
+        try (Connection connection = getConnectDBConnection()) {
+            PreparedStatement ps = connection.prepareStatement(sql);
+            ps.setString(1, hashKey);
+            ResultSet rs = ps.executeQuery();
+            while (rs.next()) {
+                sessionDataKey = rs.getString("contextid");
+            }
+        }
+        return sessionDataKey;
+    }
+
     /**
      * Handle exception.
      *

--- a/components/session-updater/src/main/webapp/WEB-INF/web.xml
+++ b/components/session-updater/src/main/webapp/WEB-INF/web.xml
@@ -25,7 +25,17 @@
         <servlet-name>ServletAdaptor</servlet-name>
         <url-pattern>/tnspoints/*</url-pattern>
     </servlet-mapping>
-    
+
+    <filter>
+        <filter-name>SMSApprovalRequestForwardingFilter</filter-name>
+        <filter-class>com.wso2telco.filters.SMSApprovalRequestForwardingFilter</filter-class>
+    </filter>
+
+    <filter-mapping>
+        <filter-name>SMSApprovalRequestForwardingFilter</filter-name>
+        <url-pattern>/wt/*</url-pattern>
+    </filter-mapping>
+
     <session-config>
         <session-timeout>
             30

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1400,6 +1400,11 @@
                 <artifactId>httpcore-nio</artifactId>
                 <version>${httpcore-nio.version}</version>
             </dependency>
+            <dependency>
+				<groupId>org.hashids</groupId>
+				<artifactId>hashids</artifactId>
+				<version>${hash.ids.version}</version>
+			</dependency>
 
         </dependencies>
 	</dependencyManagement>
@@ -1639,6 +1644,7 @@
 		<!-- wso2 telco -->
 		<org.apache.sling.commons.json.version>2.0.6</org.apache.sling.commons.json.version>
 		<org.wso2.amber.version>0.22.1358727.wso2v4</org.wso2.amber.version>
+		<hash.ids.version>1.0.1</hash.ids.version>
 		<!--from intermediate pom -->
 		<com.wso2telco.ids.version>2.0.13</com.wso2telco.ids.version>		
 
@@ -1656,6 +1662,7 @@
 		<javax.ws.rs.version>1.0</javax.ws.rs.version>
 		<com.google.code.gson.version>2.7</com.google.code.gson.version>
 		<maven-war-plugin.version>2.1.1</maven-war-plugin.version>
+		<maven-compiler-plugin.version>1.7</maven-compiler-plugin.version>
 		<org.json.wso2.version>3.0.0.wso2v1</org.json.wso2.version>
 		
 		<org.apache.felix.scr.annotations.version>1.9.6</org.apache.felix.scr.annotations.version>		


### PR DESCRIPTION
This PR adds the tomcat filter SMSApprovalRequestForwardingFilter to sessionupdater web app which forwards the requests coming for /wt request path to /tnspoints/endpoint/sms/response. The purpose is to further shorten the URL sent in SMS, in SMSAuthenticator. Also SMSAuthenticator code is refactored.

This PR needs the changes done in https://github.com/WSO2Telco/product-ids/pull/48 in order for a newly built product-ids pack to work.