### PR TITLE
Adding isLastAuthenticator property back since its needed for the general scenario to work

### DIFF
--- a/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/authenticators/LOACompositeAuthenticator.java
+++ b/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/authenticators/LOACompositeAuthenticator.java
@@ -299,11 +299,8 @@ public class LOACompositeAuthenticator implements ApplicationAuthenticator,
 							parameterMap.put("currentLOA", selectedLOA);
 							parameterMap.put("fallBack", (null != fallBack) ? fallBack : "");
 							parameterMap.put("onFail", (null != onFailAction) ? onFailAction : "");
-							//						parameterMap
-							//								.put("isLastAuthenticator",
-							//								     (authenticatorList.indexOf(authenticator) == authenticatorList.size() - 1) ?
-							//										     "true"
-							//										     : "false");
+							parameterMap.put("isLastAuthenticator", (authenticatorList
+									.indexOf(authenticator) == authenticatorList.size() - 1) ? "true" : "false");
 							authenticatorConfig.setParameterMap(parameterMap);
 
 							stepConfig.getAuthenticatorList().add(authenticatorConfig);
@@ -311,11 +308,6 @@ public class LOACompositeAuthenticator implements ApplicationAuthenticator,
 
 							stepOrder++;
 						} else {
-							//This change is just a revert back to what previously was. Need to check and change
-							if (StringUtils.isEmpty(fallBack)) {
-								selectedLOA = fallBack;
-								mifeAuthentication = authenticationMap.get(selectedLOA);
-							}
 							break;
 						}
 					}


### PR DESCRIPTION
In the LOACompositeAuthenticator, we are modifying the step map in the authentication context to have the authenticators configured in LOA.xml. There, we add whole authenticator tree including fallback authenticators. So, in case the authentication successfully happens in a given LOA it is needed to remove the fallback authenticators so that they are not executed. This isLastAuthenticator property marks the last authenticator of a given LOA therefore in the MIFEAuthenticationStepHandler, when the last authenticator for a given step is identified, the following steps (which are fallback steps) can be removed.