### PR TITLE
Adding SMS,USSD,USSDPin callbacks and missing data publishing points

### DIFF
--- a/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/authenticators/sms/SMSAuthenticator.java
+++ b/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/authenticators/sms/SMSAuthenticator.java
@@ -24,6 +24,7 @@ import com.wso2telco.gsma.authenticators.DBUtils;
 import com.wso2telco.gsma.authenticators.cryptosystem.AESencrp;
 import com.wso2telco.gsma.authenticators.util.Application;
 import com.wso2telco.gsma.authenticators.util.AuthenticationContextHelper;
+import com.wso2telco.gsma.authenticators.util.BasicFutureCallback;
 import com.wso2telco.gsma.shorten.SelectShortUrl;
 import com.wso2telco.ids.datapublisher.model.UserStatus;
 import com.wso2telco.ids.datapublisher.util.DataPublisherUtil;
@@ -41,6 +42,8 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.sql.SQLException;
 import java.util.Date;
 
 
@@ -166,7 +169,8 @@ public class SMSAuthenticator extends AbstractApplicationAuthenticator
             }
             
             DBUtils.insertAuthFlowStatus(msisdn, Constants.STATUS_PENDING, context.getContextIdentifier());
-            String smsResponse = new SendSMS().sendSMS(msisdn, messageText, operator);
+            BasicFutureCallback futureCallback = new SMSFutureCallback(userStatus.cloneUserStatus());
+            String smsResponse = new SendSMS().sendSMS(msisdn, messageText, operator, futureCallback);
             response.sendRedirect(response.encodeRedirectURL(loginPage + ("?" + queryParams)) + "&authenticators=" +
                     getName() + ":" + "LOCAL" + retryParam);
 

--- a/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/authenticators/sms/SMSFutureCallback.java
+++ b/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/authenticators/sms/SMSFutureCallback.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2017, WSO2.Telco Inc. (http://www.wso2telco.com)
+ *
+ * All Rights Reserved. WSO2.Telco Inc. licences this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package com.wso2telco.gsma.authenticators.sms;
+
+import com.wso2telco.gsma.authenticators.util.BasicFutureCallback;
+import com.wso2telco.ids.datapublisher.model.UserStatus;
+import com.wso2telco.ids.datapublisher.util.DataPublisherUtil;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpResponse;
+
+public class SMSFutureCallback extends BasicFutureCallback {
+    private static Log log = LogFactory.getLog(SMSFutureCallback.class);
+
+    private UserStatus userStatus;
+
+    SMSFutureCallback() {
+    }
+
+    SMSFutureCallback(UserStatus userStatus) {
+        this.userStatus = userStatus;
+    }
+
+    public void completed(HttpResponse response) {
+        if ((response.getStatusLine().getStatusCode() == 200)) {
+            log.info("Success Request - " + postRequest.getURI().getSchemeSpecificPart());
+            DataPublisherUtil
+                    .updateAndPublishUserStatus(userStatus, DataPublisherUtil.UserState.SEND_SMS, "SMS sent");
+
+        } else {
+            log.error("Failed Request - " + postRequest.getURI().getSchemeSpecificPart());
+            DataPublisherUtil
+                    .updateAndPublishUserStatus(userStatus, DataPublisherUtil.UserState.SEND_SMS_FAIL, "SMS sending failed");
+        }
+        closeClient();
+    }
+
+    public void failed(Exception exception) {
+        DataPublisherUtil
+                .updateAndPublishUserStatus(userStatus, DataPublisherUtil.UserState.SEND_SMS_FAIL, "SMS sending failed");
+        super.failed(exception);
+    }
+}

--- a/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/authenticators/sms/SendSMS.java
+++ b/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/authenticators/sms/SendSMS.java
@@ -17,20 +17,26 @@ package com.wso2telco.gsma.authenticators.sms;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.wso2telco.Util;
 import com.wso2telco.core.config.model.MobileConnectConfig;
 import com.wso2telco.core.config.service.ConfigurationService;
 import com.wso2telco.core.config.service.ConfigurationServiceImpl;
 import com.wso2telco.gsma.authenticators.model.ReceiptRequest;
+import com.wso2telco.gsma.authenticators.util.BasicFutureCallback;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClients;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -56,7 +62,7 @@ public class SendSMS {
      * @return the string
      * @throws IOException Signals that an I/O exception has occurred.
      */
-    protected String sendSMS(String msisdn, String message,String operator) throws IOException {
+    protected String sendSMS(String msisdn, String message, String operator, BasicFutureCallback futureCallback) throws IOException {
         String returnString = null;
         
         List<String> address = new ArrayList<String>();
@@ -95,7 +101,7 @@ public class SendSMS {
         returnString = gson.toJson(req);
 
         smsConfig = configurationService.getDataHolder().getMobileConnectConfig().getSmsConfig();
-        postRequest(smsConfig.getEndpoint(),returnString,operator);
+        postRequest(smsConfig.getEndpoint(), returnString, operator, futureCallback);
         
         return returnString;
         
@@ -109,7 +115,7 @@ public class SendSMS {
      * @param operator the operator
      * @throws IOException Signals that an I/O exception has occurred.
      */
-    protected void postRequest(String url, String requestStr,String operator) throws IOException {
+    protected void postRequest(String url, String requestStr,String operator, BasicFutureCallback futureCallback) throws IOException {
 
 
 //        HttpClient client = HttpClientBuilder.create().build();
@@ -128,14 +134,6 @@ public class SendSMS {
         
         postRequest.setEntity(input);
 
-        HttpResponse response = client.execute(postRequest);
-        
-        if ( (response.getStatusLine().getStatusCode() != 201)){
-            LOG.error("Error occured while calling end points");
-        }
-        else{
-            LOG.info("Success Request");
-        }
-        
+        Util.sendAsyncRequest(postRequest, futureCallback);
     }
 }

--- a/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/authenticators/ussd/USSDAuthenticator.java
+++ b/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/authenticators/ussd/USSDAuthenticator.java
@@ -180,7 +180,8 @@ public class USSDAuthenticator extends AbstractApplicationAuthenticator
         String client_id = paramMap.get(Constants.CLIENT_ID);
 
         UserStatus userStatus = (UserStatus)context.getParameter(Constants.USER_STATUS_DATA_PUBLISHING_PARAM);
-        ussdCommand.execute(msisdn, context.getContextIdentifier(), serviceProviderName, operator, client_id, userStatus);
+        ussdCommand.execute(msisdn, context.getContextIdentifier(), serviceProviderName, operator, client_id,
+                new USSDFutureCallback(userStatus.cloneUserStatus()));
     }
 
     /**

--- a/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/authenticators/ussd/USSDFutureCallback.java
+++ b/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/authenticators/ussd/USSDFutureCallback.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2017, WSO2.Telco Inc. (http://www.wso2telco.com)
+ *
+ * All Rights Reserved. WSO2.Telco Inc. licences this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package com.wso2telco.gsma.authenticators.ussd;
+
+import com.wso2telco.gsma.authenticators.util.BasicFutureCallback;
+import com.wso2telco.ids.datapublisher.model.UserStatus;
+import com.wso2telco.ids.datapublisher.util.DataPublisherUtil;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpResponse;
+
+public class USSDFutureCallback extends BasicFutureCallback {
+    private static Log log = LogFactory.getLog(USSDFutureCallback.class);
+
+    private UserStatus userStatus;
+
+    USSDFutureCallback() {
+    }
+
+    USSDFutureCallback(UserStatus userStatus) {
+        this.userStatus = userStatus;
+    }
+
+    public void completed(HttpResponse response) {
+        if ((response.getStatusLine().getStatusCode() == 200)) {
+            log.info("Success Request - " + postRequest.getURI().getSchemeSpecificPart());
+            DataPublisherUtil
+                    .updateAndPublishUserStatus(userStatus, DataPublisherUtil.UserState.SEND_USSD_PUSH, "USSD Push done");
+
+        } else {
+            log.error("Failed Request - " + postRequest.getURI().getSchemeSpecificPart());
+            DataPublisherUtil.updateAndPublishUserStatus(userStatus, DataPublisherUtil.UserState.SEND_USSD_PUSH_FAIL,
+                    "USSD Push failed");
+        }
+        closeClient();
+    }
+
+    public void failed(Exception exception) {
+        DataPublisherUtil.updateAndPublishUserStatus(userStatus, DataPublisherUtil.UserState.SEND_USSD_PUSH_FAIL,
+                "USSD Push failed");
+        super.failed(exception);
+    }
+}

--- a/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/authenticators/ussd/USSDPinFutureCallback.java
+++ b/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/authenticators/ussd/USSDPinFutureCallback.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2017, WSO2.Telco Inc. (http://www.wso2telco.com)
+ *
+ * All Rights Reserved. WSO2.Telco Inc. licences this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package com.wso2telco.gsma.authenticators.ussd;
+
+import com.wso2telco.gsma.authenticators.util.BasicFutureCallback;
+import com.wso2telco.ids.datapublisher.model.UserStatus;
+import com.wso2telco.ids.datapublisher.util.DataPublisherUtil;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpResponse;
+
+public class USSDPinFutureCallback extends BasicFutureCallback {
+    private static Log log = LogFactory.getLog(USSDPinFutureCallback.class);
+
+    private UserStatus userStatus;
+
+    USSDPinFutureCallback() {
+    }
+
+    USSDPinFutureCallback(UserStatus userStatus) {
+        this.userStatus = userStatus;
+    }
+
+    public void completed(HttpResponse response) {
+        if ((response.getStatusLine().getStatusCode() == 200)) {
+            log.info("Success Request - " + postRequest.getURI().getSchemeSpecificPart());
+            DataPublisherUtil
+                    .updateAndPublishUserStatus(userStatus, DataPublisherUtil.UserState.SEND_USSD_PIN, "USSD Pin sent");
+
+        } else {
+            log.error("Failed Request - " + postRequest.getURI().getSchemeSpecificPart());
+            DataPublisherUtil.updateAndPublishUserStatus(userStatus, DataPublisherUtil.UserState.SEND_USSD_PIN_FAIL,
+                    "USSD Pin sending failed");
+        }
+        closeClient();
+    }
+
+    public void failed(Exception exception) {
+        DataPublisherUtil.updateAndPublishUserStatus(userStatus, DataPublisherUtil.UserState.SEND_USSD_PIN_FAIL,
+                "USSD Pin sending failed");
+        super.failed(exception);
+    }
+}

--- a/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/authenticators/ussd/command/UssdCommand.java
+++ b/components/gsma-authenticators/src/main/java/com/wso2telco/gsma/authenticators/ussd/command/UssdCommand.java
@@ -43,9 +43,7 @@ public abstract class UssdCommand {
 
     private static Log log = LogFactory.getLog(UssdCommand.class);
 
-    public void execute(String msisdn, String sessionID, String serviceProvider, String operator, String client_id, UserStatus userStatus) throws IOException {
-        DataPublisherUtil
-                .updateAndPublishUserStatus(userStatus, DataPublisherUtil.UserState.SEND_USSD_PIN, "");
+    public void execute(String msisdn, String sessionID, String serviceProvider, String operator, String client_id, BasicFutureCallback futureCallback) throws IOException {
 //        AuthenticationContext ctx = getAuthenticationContext(sessionID);
 //        String queryParams = FrameworkUtils.getQueryStringWithFrameworkContextId(ctx.getQueryParams(),
 //                ctx.getCallerSessionKey(), ctx.getContextIdentifier());
@@ -59,7 +57,7 @@ public abstract class UssdCommand {
         Gson gson = new GsonBuilder().serializeNulls().create();
         String reqString = gson.toJson(ussdRequest);
 
-        postRequest(getUrl(msisdn), reqString, operator);
+        postRequest(getUrl(msisdn), reqString, operator, futureCallback);
     }
 
     protected abstract String getUrl(String msisdn);
@@ -75,9 +73,8 @@ public abstract class UssdCommand {
      * @return the string
      * @throws IOException Signals that an I/O exception has occurred.
      */
-    private void postRequest(String url, String requestStr, String operator) throws IOException {
+    private void postRequest(String url, String requestStr, String operator, BasicFutureCallback futureCallback) throws IOException {
         MobileConnectConfig.USSDConfig ussdConfig = DataHolder.getInstance().getMobileConnectConfig().getUssdConfig();
-        BasicFutureCallback futureCallback = new BasicFutureCallback();
         final HttpPost postRequest = futureCallback.getPostRequest();
         try {
             postRequest.setURI(new URI(url));

--- a/components/ids-data-publisher/src/main/java/com/wso2telco/ids/datapublisher/internal/DataPublisherServiceComponent.java
+++ b/components/ids-data-publisher/src/main/java/com/wso2telco/ids/datapublisher/internal/DataPublisherServiceComponent.java
@@ -48,6 +48,7 @@ public class DataPublisherServiceComponent {
     }
 
     protected void unsetApplicationManagementService(ApplicationManagementService applicationManagementService) {
+        DataPublisherUtil.setApplicationManagementService(null);
     }
 
 

--- a/components/ids-data-publisher/src/main/java/com/wso2telco/ids/datapublisher/model/UserStatus.java
+++ b/components/ids-data-publisher/src/main/java/com/wso2telco/ids/datapublisher/model/UserStatus.java
@@ -147,6 +147,13 @@ public class UserStatus {
         return transactionId;
     }
 
+    public UserStatus cloneUserStatus() {
+        return new UserStatusBuilder(getSessionId()).id(id).time(time).status(status).msisdn(msisdn).state(state)
+                .nonce(nonce).scope(scope).acrValue(acrValue).ipHeader(ipHeader).isNewUser(isNewUser)
+                .loginHint(loginHint).operator(operator).userAgent(userAgent).comment(comment).consumerKey(consumerKey)
+                .appId(appId).telcoScope(telcoScope).xForwardIP(xForwardIP).transactionId(transactionId).build();
+    }
+
     private UserStatus(UserStatusBuilder builder) {
         this.id = builder.id;
         this.time = builder.time;


### PR DESCRIPTION
This PR depends on https://github.com/WSO2Telco/product-ids/pull/64 and https://github.com/WSO2Telco/core-util/pull/71.

This adds SMS,USSD,USSDPin callbacks which have been used to log and publish data at the success of sending SMS/USSD/USSDPin. Please note that separate child classes were added for each of these in case in the future there might be different actions to be taken place once SMS/USSD/USSDpin success/failure.